### PR TITLE
Default to the Original Shape

### DIFF
--- a/app/ItemView/PlayerContainer.tsx
+++ b/app/ItemView/PlayerContainer.tsx
@@ -42,7 +42,7 @@ const PlayerContainer: React.FC<PlayerContainerProps> = (props) => {
     const shapeMatches = props.shapes
       .filter((shape) => shape.tag.length > 0)
       .filter((shape) => props.defaultShapes.includes(shape.tag[0]));
-    return shapeMatches.length > 0 ? shapeMatches[0].tag[0] : "";
+    return shapeMatches.length > 0 ? shapeMatches[0].tag[0] : "original";
   };
 
   const [selectedShapeTag, setSelectedShapeTag] = useState<string>(


### PR DESCRIPTION
## What does this change?

Items with none of the default shape types such as text files should now have the original shape selected to start off with.