### PR TITLE
Make Previous and Next Buttons Work

### DIFF
--- a/app/Frontpage.tsx
+++ b/app/Frontpage.tsx
@@ -297,6 +297,7 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
           onLoadPreviousClicked={() => {
             setLoadFrom((currentValue) => currentValue - 500);
           }}
+          searching={searching}
         />
       </div>
       <div className="results-container" ref={resultsContainerRef}>

--- a/app/Frontpage.tsx
+++ b/app/Frontpage.tsx
@@ -119,7 +119,7 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
     previousItemList?: VidispineItem[]
   ) => {
     setSearching(true);
-    const fromParam = startAt ?? itemList.length;
+    const fromParam = startAt ?? loadFrom + itemList.length;
     const shouldCount: boolean = fromParam == 0;
     const searchUrl = `${
       vidispineContext?.baseUrl
@@ -165,8 +165,16 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
       }
 
       if (serverContent.data.item) {
-        if (serverContent.data.item.length < pageSize)
+        if (serverContent.data.item.length < pageSize) {
           setMoreItemsAvailable(false);
+        } else {
+          setMoreItemsAvailable(true);
+        }
+        if (loadFrom == 0) {
+          setPreviousItemsAvailable(false);
+        } else {
+          setPreviousItemsAvailable(true);
+        }
         //only add in items that validate as VidispineItem. Items that don't are logged to console.
         const existingList = previousItemList ?? itemList;
         const updatedItemList = existingList.concat(
@@ -182,7 +190,8 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
         ) {
           //allow the javascript engine to process state updates above before recursing on to next page.
           window.setTimeout(
-            () => loadNextPage(updatedItemList.length, updatedItemList),
+            () =>
+              loadNextPage(updatedItemList.length + loadFrom, updatedItemList),
             200
           );
         } else {
@@ -232,8 +241,8 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
     console.log("Search updated, reloading...");
     setLastError(undefined);
     //give the above a chance to execute before we kick off the download
-    window.setTimeout(() => loadNextPage(0, []), 100);
-  }, [currentSearch]);
+    window.setTimeout(() => loadNextPage(loadFrom, []), 100);
+  }, [currentSearch, loadFrom]);
 
   if (redirectToItem) return <Redirect to={`/item/${redirectToItem}`} />;
 

--- a/app/Frontpage.tsx
+++ b/app/Frontpage.tsx
@@ -284,6 +284,7 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
           onUpdated={(newSearch) => {
             console.log("Got new search doc: ", newSearch);
             setCurrentSearch(newSearch);
+            setLoadFrom(0);
           }}
           onHideToggled={(newValue) => setHideSearchBox(newValue)}
           isHidden={hideSearchBox}

--- a/app/Frontpage.tsx
+++ b/app/Frontpage.tsx
@@ -44,10 +44,11 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
   const [pageSize, setPageSize] = useState<number>(20);
   const [itemLimit, setItemLimit] = useState<number>(props.itemLimit ?? 500);
   const [moreItemsAvailable, setMoreItemsAvailable] = useState(false);
-
+  const [loadFrom, setLoadFrom] = useState<number>(0);
   const [itemList, setItemList] = useState<VidispineItem[]>([]);
   const [totalItems, setTotalItems] = useState<number>(0);
   const [facetList, setFacetList] = useState<FacetCountResponse[]>([]);
+  const [previousItemsAvailable, setPreviousItemsAvailable] = useState(false);
 
   const [redirectToItem, setRedirectToItem] = useState<string | undefined>(
     undefined
@@ -279,9 +280,13 @@ const FrontpageComponent: React.FC<FrontpageComponentProps> = (props) => {
           isHidden={hideSearchBox}
           projectIdToLoad={props.projectIdToLoad}
           moreItemsAvailable={moreItemsAvailable}
-          onLoadMoreClicked={() =>
-            setPageSize((currentValue) => currentValue + 50)
-          }
+          onLoadMoreClicked={() => {
+            setLoadFrom((currentValue) => currentValue + 500);
+          }}
+          previousItemsAvailable={previousItemsAvailable}
+          onLoadPreviousClicked={() => {
+            setLoadFrom((currentValue) => currentValue - 500);
+          }}
         />
       </div>
       <div className="results-container" ref={resultsContainerRef}>

--- a/app/Frontpage/VidispineSearchForm.tsx
+++ b/app/Frontpage/VidispineSearchForm.tsx
@@ -30,6 +30,7 @@ interface VidispineSearchFormProps {
   moreItemsAvailable?: boolean;
   onLoadPreviousClicked?: () => void;
   previousItemsAvailable?: boolean;
+  searching?: boolean;
 }
 
 interface SearchEntry {
@@ -119,7 +120,9 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
                 >
                   <span>
                     <Button
-                      disabled={!props.previousItemsAvailable}
+                      disabled={
+                        !props.previousItemsAvailable || props.searching
+                      }
                       onClick={() =>
                         props.onLoadPreviousClicked
                           ? props.onLoadPreviousClicked()
@@ -141,7 +144,7 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
                 >
                   <span>
                     <Button
-                      disabled={!props.moreItemsAvailable}
+                      disabled={!props.moreItemsAvailable || props.searching}
                       onClick={() =>
                         props.onLoadMoreClicked
                           ? props.onLoadMoreClicked()
@@ -155,7 +158,11 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
               </Grid>
               <Grid item>
                 <Tooltip title="Start a new search from the first item">
-                  <Button variant="contained" onClick={makeSearchDoc}>
+                  <Button
+                    variant="contained"
+                    onClick={makeSearchDoc}
+                    disabled={props.searching}
+                  >
                     Search
                   </Button>
                 </Tooltip>

--- a/app/Frontpage/VidispineSearchForm.tsx
+++ b/app/Frontpage/VidispineSearchForm.tsx
@@ -28,6 +28,8 @@ interface VidispineSearchFormProps {
   projectIdToLoad?: number;
   onLoadMoreClicked?: () => void;
   moreItemsAvailable?: boolean;
+  onLoadPreviousClicked?: () => void;
+  previousItemsAvailable?: boolean;
 }
 
 interface SearchEntry {
@@ -110,8 +112,30 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
               <Grid item>
                 <Tooltip
                   title={
+                    props.previousItemsAvailable
+                      ? "Load the previous 500 items"
+                      : "There are no previous items"
+                  }
+                >
+                  <span>
+                    <Button
+                      disabled={!props.previousItemsAvailable}
+                      onClick={() =>
+                        props.onLoadPreviousClicked
+                          ? props.onLoadPreviousClicked()
+                          : undefined
+                      }
+                    >
+                      Previous 500
+                    </Button>
+                  </span>
+                </Tooltip>
+              </Grid>
+              <Grid item>
+                <Tooltip
+                  title={
                     props.moreItemsAvailable
-                      ? "Load in 50 more items"
+                      ? "Load the next 500 items"
                       : "All of the search results are displayed"
                   }
                 >
@@ -124,7 +148,7 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
                           : undefined
                       }
                     >
-                      Load more
+                      Next 500
                     </Button>
                   </span>
                 </Tooltip>

--- a/app/Nearline.tsx
+++ b/app/Nearline.tsx
@@ -280,6 +280,7 @@ const NearlineComponent: React.FC<FrontpageComponentProps> = (props) => {
           onUpdated={(newSearch) => {
             console.log("Got new search doc: ", newSearch);
             setCurrentSearch(newSearch);
+            setLoadFrom(0);
           }}
           onHideToggled={(newValue) => setHideSearchBox(newValue)}
           isHidden={hideSearchBox}

--- a/app/Nearline.tsx
+++ b/app/Nearline.tsx
@@ -293,6 +293,7 @@ const NearlineComponent: React.FC<FrontpageComponentProps> = (props) => {
           onLoadPreviousClicked={() => {
             setLoadFrom((currentValue) => currentValue - 500);
           }}
+          searching={searching}
         />
       </div>
       <div className="results-container" ref={resultsContainerRef}>

--- a/app/Nearline/VidispineSearchForm.tsx
+++ b/app/Nearline/VidispineSearchForm.tsx
@@ -30,6 +30,7 @@ interface VidispineSearchFormProps {
   moreItemsAvailable?: boolean;
   onLoadPreviousClicked?: () => void;
   previousItemsAvailable?: boolean;
+  searching?: boolean;
 }
 
 interface SearchEntry {
@@ -125,7 +126,9 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
                 >
                   <span>
                     <Button
-                      disabled={!props.previousItemsAvailable}
+                      disabled={
+                        !props.previousItemsAvailable || props.searching
+                      }
                       onClick={() =>
                         props.onLoadPreviousClicked
                           ? props.onLoadPreviousClicked()
@@ -147,7 +150,7 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
                 >
                   <span>
                     <Button
-                      disabled={!props.moreItemsAvailable}
+                      disabled={!props.moreItemsAvailable || props.searching}
                       onClick={() =>
                         props.onLoadMoreClicked
                           ? props.onLoadMoreClicked()
@@ -161,7 +164,11 @@ const VidispineSearchForm: React.FC<VidispineSearchFormProps> = (props) => {
               </Grid>
               <Grid item>
                 <Tooltip title="Start a new search from the first item">
-                  <Button variant="contained" onClick={makeSearchDoc}>
+                  <Button
+                    variant="contained"
+                    onClick={makeSearchDoc}
+                    disabled={props.searching}
+                  >
                     Search
                   </Button>
                 </Tooltip>


### PR DESCRIPTION
## What does this change?

Replaces the broken 'load more' button with working 'previous 500' and 'next 500' buttons. Also disables these and the search button when data is loading.


