### PR TITLE
Remove Forwarding to pluto-start

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -151,23 +151,6 @@ const App: React.FC<{}> = () => {
     initialiseComponent();
   }, []);
 
-  useEffect(() => {
-    if (!window.location.href.includes("embed")) {
-      const timeout = setTimeout(() => {
-        if (!isLoggedIn) {
-          console.log("Not logged in, redirecting to pluto-start.");
-          window.location.assign(
-            "/refreshLogin?returnTo=" + window.location.pathname
-          );
-        }
-      }, 3000);
-
-      return () => {
-        clearTimeout(timeout);
-      };
-    }
-  }, [isLoggedIn]);
-
   if (window.location.href.includes("embed")) {
     //if we are embedding, we just need a minimum of decorations so don't load the full UI
     return (


### PR DESCRIPTION
## What does this change?

Removes the forwarding code as it is not compatible with Azure.

## How can we measure success?

The software no longer attempts to forward the browser to pluto-start.

## Have we considered potential risks?

Yes. This is completely safe. Removing the code should do nothing apart from cause the software to stop forwarding to a currently broken URL.