### PR TITLE
Fix Metadata Uploads Under macOS 12

### DIFF
--- a/vs-metadata/deploy.py
+++ b/vs-metadata/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import requests
 from argparse import ArgumentParser

--- a/vs-metadata/validate.py
+++ b/vs-metadata/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import xml.etree.cElementTree as ET
 import sys


### PR DESCRIPTION
## What does this change?

Fixes metadata validation and upload under macOS 12.

## How can we measure success?

The scripts work under macOS 12.

## Have we considered potential risks?

Please note that this will likely break the scripts under older versions of macOS.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2.
