### PR TITLE
Asset download

### DIFF
--- a/app/Embeddable/EmbeddablePlayer.tsx
+++ b/app/Embeddable/EmbeddablePlayer.tsx
@@ -52,6 +52,16 @@ const EmbeddablePlayer: React.FC<RouteComponentProps> = (props) => {
     }
   }, [vidispineContext]);
 
+  const originalFilename = () => {
+    if (!itemData) return "asset";
+    const possibleFilename = itemData.getMetadataString("originalFilename");
+    if (possibleFilename) {
+      return `${possibleFilename as string}`;
+    } else {
+      return `asset`;
+    }
+  };
+
   return (
     <div id="mediabrowser-embed">
       {loading ? <CircularProgress /> : undefined}
@@ -60,6 +70,7 @@ const EmbeddablePlayer: React.FC<RouteComponentProps> = (props) => {
           shapes={itemData.shape}
           defaultShapes={defaultShapes}
           uriList={itemData.files.uri}
+          originalFilename={originalFilename()}
         />
       ) : (
         <Typography variant="caption">No shapes exist on this item</Typography>

--- a/app/Embeddable/EmbeddablePlayer.tsx
+++ b/app/Embeddable/EmbeddablePlayer.tsx
@@ -53,12 +53,12 @@ const EmbeddablePlayer: React.FC<RouteComponentProps> = (props) => {
   }, [vidispineContext]);
 
   const originalFilename = () => {
-    if (!itemData) return "asset";
+    if (!itemData) return undefined;
     const possibleFilename = itemData.getMetadataString("originalFilename");
     if (possibleFilename) {
       return `${possibleFilename as string}`;
     } else {
-      return `asset`;
+      return undefined;
     }
   };
 

--- a/app/ItemView/PlayerContainer.tsx
+++ b/app/ItemView/PlayerContainer.tsx
@@ -115,7 +115,7 @@ const PlayerContainer: React.FC<PlayerContainerProps> = (props) => {
     const matcher = new RegExp(`${fileId}\..*$`);
     //uri.search returns the index in the string of a match, or -1 if there is no match
     const matchingUris = props.uriList.filter((uri) => uri.search(matcher) > 0);
-    console.log(matchingUris);
+    console.log("Matching Uris: ", matchingUris);
     console.debug(`Found ${matchingUris.length} matching URIs`);
 
     if (matchingUris.length > 0) {

--- a/app/ItemView/PlayerContainer.tsx
+++ b/app/ItemView/PlayerContainer.tsx
@@ -21,7 +21,7 @@ interface PlayerContainerProps {
   shapes: VidispineShape[];
   uriList: string[];
   defaultShapes: string[];
-  originalFilename: string;
+  originalFilename: string | undefined;
 }
 
 const useStyles = makeStyles({
@@ -129,9 +129,13 @@ const PlayerContainer: React.FC<PlayerContainerProps> = (props) => {
 
   useEffect(() => {
     let baseUri = playerUri.replace(":8080", "");
-    let baseUrl = baseUri.slice(0, baseUri.lastIndexOf("/") + 1);
-    let newTargetUrl = baseUrl + props.originalFilename;
-    setTargetUrl(newTargetUrl);
+    if (props.originalFilename === undefined) {
+      setTargetUrl(baseUri);
+    } else {
+      let baseUrl = baseUri.slice(0, baseUri.lastIndexOf("/") + 1);
+      let newTargetUrl = baseUrl + props.originalFilename;
+      setTargetUrl(newTargetUrl);
+    }
   }, [playerUri, props.originalFilename]);
 
   /**

--- a/app/ItemView/PlayerContainer.tsx
+++ b/app/ItemView/PlayerContainer.tsx
@@ -119,6 +119,7 @@ const PlayerContainer: React.FC<PlayerContainerProps> = (props) => {
     console.log("Matching Uris: ", matchingUris);
     console.debug(`Found ${matchingUris.length} matching URIs`);
     const originalFilename = props.originalFilename;
+
     if (matchingUris.length > 0) {
       setPlayerUri(matchingUris[0]);
     } else {
@@ -127,10 +128,11 @@ const PlayerContainer: React.FC<PlayerContainerProps> = (props) => {
   }, [selectedShapeTag]);
 
   useEffect(() => {
-    setTargetUrl(`${playerUri.replace(":8080", "")}`);
-    console.log("targetUrl is ", targetUrl);
-    console.log("originalFilename is ", props.originalFilename);
-  }, [playerUri]);
+    let baseUri = playerUri.replace(":8080", "");
+    let baseUrl = baseUri.slice(0, baseUri.lastIndexOf("/") + 1);
+    let newTargetUrl = baseUrl + props.originalFilename;
+    setTargetUrl(newTargetUrl);
+  }, [playerUri, props.originalFilename]);
 
   /**
    * returns the VidispineShape data structure associated with the shape matching the selected tag

--- a/app/ItemView/PlayerContainer.tsx
+++ b/app/ItemView/PlayerContainer.tsx
@@ -21,6 +21,7 @@ interface PlayerContainerProps {
   shapes: VidispineShape[];
   uriList: string[];
   defaultShapes: string[];
+  originalFilename: string;
 }
 
 const useStyles = makeStyles({
@@ -117,7 +118,7 @@ const PlayerContainer: React.FC<PlayerContainerProps> = (props) => {
     const matchingUris = props.uriList.filter((uri) => uri.search(matcher) > 0);
     console.log("Matching Uris: ", matchingUris);
     console.debug(`Found ${matchingUris.length} matching URIs`);
-
+    const originalFilename = props.originalFilename;
     if (matchingUris.length > 0) {
       setPlayerUri(matchingUris[0]);
     } else {
@@ -127,6 +128,8 @@ const PlayerContainer: React.FC<PlayerContainerProps> = (props) => {
 
   useEffect(() => {
     setTargetUrl(`${playerUri.replace(":8080", "")}`);
+    console.log("targetUrl is ", targetUrl);
+    console.log("originalFilename is ", props.originalFilename);
   }, [playerUri]);
 
   /**

--- a/app/ItemViewComponent.tsx
+++ b/app/ItemViewComponent.tsx
@@ -38,7 +38,6 @@ const ItemViewComponent: React.FC<RouteComponentProps<
   useEffect(() => {
     if (vidispineContext) {
       console.log(`Loading item with id ${props.match.params.itemId}`);
-      console.log(`Item params are:  ${props.match.params}`);
       loadItemMeta(vidispineContext.baseUrl, props.match.params.itemId)
         .then((newItemData) => {
           setItemData(newItemData);
@@ -68,12 +67,12 @@ const ItemViewComponent: React.FC<RouteComponentProps<
   };
 
   const originalFilename = () => {
-    if (!itemData) return "asset";
+    if (!itemData) return "asset_download";
     const possibleFilename = itemData.getMetadataString("originalFilename");
     if (possibleFilename) {
       return `${possibleFilename as string}`;
     } else {
-      return `asset`;
+      return "asset_download";
     }
   };
 
@@ -97,14 +96,6 @@ const ItemViewComponent: React.FC<RouteComponentProps<
       ) : null}
       {itemData ? (
         <>
-          {console.log("ItemData is ", itemData)}
-          {console.log("ItemData metadata is ", itemData.metadata)}
-          {console.log(
-            "ItemData getMetadataString originalFilename is",
-            itemData.getMetadataString("originalFilename")
-          )}
-          {console.log("ItemData.shape is ", itemData.shape)}
-          {console.log("ItemData.files is ", itemData.files)}
           {itemData && itemData.shape && itemData.files ? (
             <PlayerContainer
               shapes={itemData.shape}

--- a/app/ItemViewComponent.tsx
+++ b/app/ItemViewComponent.tsx
@@ -67,6 +67,16 @@ const ItemViewComponent: React.FC<RouteComponentProps<
     }
   };
 
+  const originalFilename = () => {
+    if (!itemData) return "asset";
+    const possibleFilename = itemData.getMetadataString("originalFilename");
+    if (possibleFilename) {
+      return `${possibleFilename as string}`;
+    } else {
+      return `asset`;
+    }
+  };
+
   return (
     <>
       {itemData ? (
@@ -90,8 +100,8 @@ const ItemViewComponent: React.FC<RouteComponentProps<
           {console.log("ItemData is ", itemData)}
           {console.log("ItemData metadata is ", itemData.metadata)}
           {console.log(
-            "ItemData getmetadata is",
-            itemData.getMetadataString("path")
+            "ItemData getMetadataString originalFilename is",
+            itemData.getMetadataString("originalFilename")
           )}
           {console.log("ItemData.shape is ", itemData.shape)}
           {console.log("ItemData.files is ", itemData.files)}
@@ -100,6 +110,7 @@ const ItemViewComponent: React.FC<RouteComponentProps<
               shapes={itemData.shape}
               defaultShapes={defaultShapes}
               uriList={itemData.files.uri}
+              originalFilename={originalFilename()}
             />
           ) : (
             <Typography variant="caption">

--- a/app/ItemViewComponent.tsx
+++ b/app/ItemViewComponent.tsx
@@ -38,6 +38,7 @@ const ItemViewComponent: React.FC<RouteComponentProps<
   useEffect(() => {
     if (vidispineContext) {
       console.log(`Loading item with id ${props.match.params.itemId}`);
+      console.log(`Item params are:  ${props.match.params}`);
       loadItemMeta(vidispineContext.baseUrl, props.match.params.itemId)
         .then((newItemData) => {
           setItemData(newItemData);
@@ -67,7 +68,7 @@ const ItemViewComponent: React.FC<RouteComponentProps<
   };
 
   return (
-    <>
+    <> 
       {itemData ? (
         <Helmet>
           <title>{pageTitle()}</title>
@@ -86,6 +87,11 @@ const ItemViewComponent: React.FC<RouteComponentProps<
       ) : null}
       {itemData ? (
         <>
+          {console.log("ItemData is ", itemData)}
+          {console.log("ItemData metadata is ", itemData.metadata)}
+          {console.log("ItemData getmetadata is", itemData.getMetadataString("path"))}
+          {console.log("ItemData.shape is ", itemData.shape)}
+          {console.log("ItemData.files is ", itemData.files)}
           {itemData && itemData.shape && itemData.files ? (
             <PlayerContainer
               shapes={itemData.shape}

--- a/app/ItemViewComponent.tsx
+++ b/app/ItemViewComponent.tsx
@@ -68,7 +68,7 @@ const ItemViewComponent: React.FC<RouteComponentProps<
   };
 
   return (
-    <> 
+    <>
       {itemData ? (
         <Helmet>
           <title>{pageTitle()}</title>
@@ -89,7 +89,10 @@ const ItemViewComponent: React.FC<RouteComponentProps<
         <>
           {console.log("ItemData is ", itemData)}
           {console.log("ItemData metadata is ", itemData.metadata)}
-          {console.log("ItemData getmetadata is", itemData.getMetadataString("path"))}
+          {console.log(
+            "ItemData getmetadata is",
+            itemData.getMetadataString("path")
+          )}
           {console.log("ItemData.shape is ", itemData.shape)}
           {console.log("ItemData.files is ", itemData.files)}
           {itemData && itemData.shape && itemData.files ? (

--- a/app/ItemViewComponent.tsx
+++ b/app/ItemViewComponent.tsx
@@ -67,12 +67,12 @@ const ItemViewComponent: React.FC<RouteComponentProps<
   };
 
   const originalFilename = () => {
-    if (!itemData) return "asset_download";
+    if (!itemData) return undefined;
     const possibleFilename = itemData.getMetadataString("originalFilename");
     if (possibleFilename) {
       return `${possibleFilename as string}`;
     } else {
-      return "asset_download";
+      return undefined;
     }
   };
 

--- a/app/vidispine/shape/VidispineShape-ti.ts
+++ b/app/vidispine/shape/VidispineShape-ti.ts
@@ -100,10 +100,10 @@ export const VidispineVideoComponent = t.iface([], {
 });
 
 export const VidispineBinaryComponent = t.iface([], {
+  file: t.array("VidispineFile"),
   id: "string",
-  length: t.opt("number"),
-  file: t.opt(t.array("VidispineFile")),
   metadata: t.opt(t.array("DataPair")),
+  length: t.opt("number"),
 });
 
 export const VidispineShapeIF = t.iface([], {


### PR DESCRIPTION
This PR fixes an issue where assets were getting their Vidispine id as a filename when downloading.
Now the file is renamed with the original filename if defined, otherwise the vidispine filename.

Tested on the dev. system.
