### PR TITLE
Upgrading Pluto Headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
-    "@guardian/pluto-headers": "v2.0.4",
+    "@guardian/pluto-headers": "v2.1.1",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,10 +1408,10 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@guardian/pluto-headers@v2.0.4":
-  version "2.0.4"
-  resolved "https://npm.pkg.github.com/download/@guardian/pluto-headers/2.0.4/5b5e2aa2fd7557dddf8e66c226fc1b0299455a64#5b5e2aa2fd7557dddf8e66c226fc1b0299455a64"
-  integrity sha512-9g/g0D+U08CT5sfSeNZDTR2C8xDTHEYzrhqEo+g8DDp67BCuf0Sc1tt2nrR+mJoz0z+jat2xUVIW/QJFniYmwA==
+"@guardian/pluto-headers@v2.1.1":
+  version "2.1.1"
+  resolved "https://npm.pkg.github.com/download/@guardian/pluto-headers/2.1.1/cf8f63c25f46a15ab7c3c23b73e1c65230f07b1e#cf8f63c25f46a15ab7c3c23b73e1c65230f07b1e"
+  integrity sha512-AsAoCnQDS9V2RNMDJIdi6KlZaKUw8iczWH9lWyKwkS666p46H83O8+FBTceui1M1LKLNfQSV2MW/MyQUYOyC9Q==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
## What does this change?

Uses a new version of Pluto Headers which has a help button.

## How can we measure success?

The new version of Pluto Headers is used.

## Have we considered potential risks?

## Images

![Screenshot 2024-12-19 at 15 39 34](https://github.com/user-attachments/assets/5cccf040-df39-41f3-8c0a-e5daea30d458)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.